### PR TITLE
Add classification functionality for two categories

### DIFF
--- a/R/classifyNB.R
+++ b/R/classifyNB.R
@@ -52,8 +52,14 @@ classifyNB <- function(est, test_matrix, test) {
   ##Trim test dfm to include only features in training data
   test_matrix <- test_matrix[, (quanteda::featnames(test_matrix) %in% colnames(w_jc))]
   ##Trim trained model include only features in test matrix and reorder to match test matrix
-  w_jc <- w_jc[, quanteda::featnames(test_matrix)]
-
+  if (length(rownames(w_jc)) == 1) { # convert w_jc back to matrix when number of categories is 2
+    rows <- rownames(w_jc)
+    w_jc <- w_jc[, quanteda::featnames(test_matrix)]
+    w_jc <- t(as.matrix(w_jc))
+    rownames(w_jc) <- rows
+  } else {
+    w_jc <- w_jc[, quanteda::featnames(test_matrix)]
+  }
   ##Convert test dfm to appearance indicators instead of counts
   if (any(test_matrix@x > 1)) {
     test_matrix@x[test_matrix@x > 1] <- 1

--- a/R/trainNB.R
+++ b/R/trainNB.R
@@ -154,9 +154,17 @@ trainNB <- function(coding,
   ########################################################################################
   ## Main training steps
   foo <- log( (1 - t(theta_jc[-c, ]))/(1 - theta_jc[c, ]) ) #intermediate step to build baseline log odds of each category
+  if (c == 2) { # transpose foo and add colnames when number of categories is 2
+    foo <- t(foo)
+    colnames(foo) <- rownames(theta_jc)[1]
+  }
   foo <- apply(foo, 2, sum) #intermediate step to build baseline log odds of each category
   w_0c <- foo + log(theta_c[-c] / theta_c[c]) #baseline log odds of categories (invariant to words in vector x_i)
   w_jc <- log((theta_jc[-c, ] * (1 - theta_jc[c, ]) / (theta_jc[c, ] * (1 - theta_jc[-c, ])))) #variable portion of log odds, depending on words in vector x_i
+  if (c == 2) { # convert w_jc from a vector into a matrix when number of categories is 2
+    w_jc <- t(as.matrix(w_jc))
+    rownames(w_jc) <- rownames(theta_jc)[1]
+  }
 
   return( list( w_0c = w_0c, w_jc = w_jc, nc = nc, theta_c = theta_c ) ) #return stuff to make forecasts on new data
 }


### PR DESCRIPTION
Added code to classify based on just two categories. Not really sure yet about setting the row- and colnames correctly. Setting these is based on the following assumption:

Based on comparison between rownames(theta_jc) and rownames(w_jc) it turns out that the last category is dropped from theta_jc when constructing w_jc.
Assuming this pattern holds also when using two categories, w_jc should be a matrix with one row, with the rowname equaling the first rowname in theta_jc
